### PR TITLE
Remove unused Vercel token variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,6 @@ NOTION_ASSETS_DB=your_assets_database_id
 NOTION_SCRIPTS_DB=your_scripts_database_id
 
 # Vercel/Deployment
-VERCEL_TOKEN=your_vercel_token
 NEXT_PUBLIC_API_URL=https://your-domain.vercel.app
 
 # AV Platform Settings


### PR DESCRIPTION
## Summary
- remove the example `VERCEL_TOKEN` entry from `.env.example`

## Testing
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863034cb6d48330bbfa20f9601d2687