### PR TITLE
Add missing API tests

### DIFF
--- a/tests/configApi.test.js
+++ b/tests/configApi.test.js
@@ -1,0 +1,41 @@
+import handler from '../src/pages/api/config';
+import * as notion from '../src/lib/notion';
+
+describe('Config API', () => {
+  const createMockRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns 405 on POST', async () => {
+    const req = { method: 'POST' };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Method not allowed' });
+  });
+
+  test('returns 500 when getNotionConfig fails', async () => {
+    const req = { method: 'GET' };
+    const res = createMockRes();
+
+    jest.spyOn(notion, 'getNotionConfig').mockRejectedValue(new Error('fail'));
+    jest.spyOn(notion, 'getAutomationScripts').mockResolvedValue([]);
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      error: 'Failed to fetch configuration',
+      notionSync: 'error',
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `src/pages/api/config` covering POST handling and errors

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68630368440883308c17360c2f4e58e8